### PR TITLE
Fix ignoreCase flag in src/RegEx/init.lua

### DIFF
--- a/src/RegEx/init.lua
+++ b/src/RegEx/init.lua
@@ -91,7 +91,7 @@ end;
 
 --
 local flag_map = {
-	a = 'anchored', i = 'caseless', m = 'multiline', s = 'dotall', u = 'unicode', U = 'ungreedy', x ='extended',
+	a = 'anchored', i = 'ignoreCase', m = 'multiline', s = 'dotall', u = 'unicode', U = 'ungreedy', x ='extended',
 };
 
 local posix_class_names = {
@@ -1959,7 +1959,7 @@ function re.new(...)
 	end;
 
 	local flags = {
-		anchored = false, caseless = false, multiline = false, dotall = false, unicode = false, ungreedy = false, extended = false,
+		anchored = false, ignoreCase = false, multiline = false, dotall = false, unicode = false, ungreedy = false, extended = false,
 	};
 	local flag_repr = { };
 	for f in string.gmatch(flags_str or '', utf8.charpattern) do
@@ -2005,7 +2005,7 @@ function re.fromstring(...)
 	until escape_count % 2 == 1;
 
 	local flags = {
-		anchored = false, caseless = false, multiline = false, dotall = false, unicode = false, ungreedy = false, extended = false,
+		anchored = false, ignoreCase = false, multiline = false, dotall = false, unicode = false, ungreedy = false, extended = false,
 	};
 	local flag_repr = { };
 	while str_arr.n > i0 do


### PR DESCRIPTION
## Summary
The RegEx code refers to `flag.ignoreCase` to accomplish ignored-case pattern matching, but the string in the `flag_map` (which is used to set the flag object, see [here](https://github.com/Roblox/luau-regexp/blob/main/src/RegEx/init.lua#L1969)) is labelled 'caseless' instead of 'ignoreCase'.

## Testing:
Tested with a pattern that works for lowercase text but not the identical (but uppercased) text (using `RegExp(pattern, "i")`

Before the change, it fails to match uppercase version. After the change, it matches.

---

### AI Summary

- Fixes `ignoreCase` flag handling in `src/RegEx/init.lua` by replacing `caseless` references with `ignoreCase` in `flag_map` and flag initialization in `re.new` and `re.fromstring`.

---
<sub>This PR summary is AI-generated. Verify the code changes, as errors may occur, and share feedback in [#code-center](https://rbx.enterprise.slack.com/archives/C053LPPLF6X).</sub>
<sub>Note: The AI summary covers objective PR changes. The author must verify accuracy and add business context such as purpose, testing, and rollout plans.</sub>

Is this PR summary helpful? :thumbsup: :thumbsdown: